### PR TITLE
Add the ability to remove voyager-hooks in production

### DIFF
--- a/publishable/config/voyager-hooks.php
+++ b/publishable/config/voyager-hooks.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    // Disables the hooks in production to avoid conflicts
+    // in the composer.json file
+    'disable_in_production' => true,
+
+    // Adds the appropriate routing to each hook
+    // on installation.
+    // If this is set to false, hooks can only be installed/removed
+    // via the CLI.
+    'add-route' => true,
+];

--- a/publishable/config/voyager-hooks.php
+++ b/publishable/config/voyager-hooks.php
@@ -3,7 +3,7 @@
 return [
     // Disables the hooks in production to avoid conflicts
     // in the composer.json file
-    'disable_in_production' => true,
+    'disable' => true,
 
     // Adds the appropriate routing to each hook
     // on installation.

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -14,7 +14,7 @@ class VoyagerHooksServiceProvider extends ServiceProvider
     public function register()
     {
         if (config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
-            return true;
+            return;
         }
 
         if ($this->app->runningInConsole()) {

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -45,7 +45,7 @@ class VoyagerHooksServiceProvider extends ServiceProvider
     public function boot(Dispatcher $events)
     {
         if (config('voyager-hooks.disable', false) {
-            return true;
+            return;
         }
 
         if (config('voyager-hooks.add-route', true)) {

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -13,9 +13,10 @@ class VoyagerHooksServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if (config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
+        if (config('voyager-hooks.disable', false) {
             return;
         }
+            
 
         if ($this->app->runningInConsole()) {
             $config = dirname(__DIR__) . '/publishable/config/voyager-hooks.php';

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -13,7 +13,7 @@ class VoyagerHooksServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if(config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
+        if (config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
             return true;
         }
 
@@ -21,7 +21,7 @@ class VoyagerHooksServiceProvider extends ServiceProvider
         $this->app->register(HooksServiceProvider::class);
 
         // Load views
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'voyager-hooks');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'voyager-hooks');
     }
 
     /**
@@ -33,7 +33,7 @@ class VoyagerHooksServiceProvider extends ServiceProvider
      */
     public function boot(Dispatcher $events)
     {
-        if(config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
+        if (config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
             return true;
         }
 

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -44,7 +44,7 @@ class VoyagerHooksServiceProvider extends ServiceProvider
      */
     public function boot(Dispatcher $events)
     {
-        if (config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
+        if (config('voyager-hooks.disable', false) {
             return true;
         }
 

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -17,6 +17,16 @@ class VoyagerHooksServiceProvider extends ServiceProvider
             return true;
         }
 
+        if ($this->app->runningInConsole()) {
+            $config = dirname(__DIR__) . '/publishable/config/voyager-hooks.php';
+
+            $this->publishes(
+                [$config => config_path('voyager-hooks.php')],
+                'Voyager-hooks config'
+            );
+        }
+
+
         // Register the HooksServiceProvider
         $this->app->register(HooksServiceProvider::class);
 

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -13,6 +13,10 @@ class VoyagerHooksServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        if(config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
+            return true;
+        }
+
         // Register the HooksServiceProvider
         $this->app->register(HooksServiceProvider::class);
 
@@ -24,9 +28,15 @@ class VoyagerHooksServiceProvider extends ServiceProvider
      * Bootstrap the application services.
      *
      * @param \Illuminate\Events\Dispatcher $events
+     *
+     * @return bool
      */
     public function boot(Dispatcher $events)
     {
+        if(config('voyager-hooks.disable_in_production', false) && config('app.env', 'production') === 'production') {
+            return true;
+        }
+
         if (config('voyager-hooks.add-route', true)) {
             $events->listen('voyager.admin.routing', [$this, 'addHookRoute']);
         }


### PR DESCRIPTION
Adds the ability to off the ability to mess with in production completely.

This will still show the hooks button in the admin UI, but a PR for that will be sent to Voyager soon.

The PR was inspired by this thread: https://github.com/the-control-group/voyager/issues/1956