### PR TITLE
Laravel 5.5.* package auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install using composer:
 composer require larapack/voyager-hooks
 ```
 
-Then add the service provider to the configuration:
+Then add the service provider to the configuration (optional on Laravel 5.5+):
 
 ```php
 'providers' => [

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,12 @@
         "psr-4": {
             "Larapack\\VoyagerHooks\\Tests\\": "tests/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Larapack\\VoyagerHooks\\VoyagerHooksServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
With this, we don't have to include de ServiceProvider to the `app.php` file manually.

More info here :point_right: [Laravel package auto-discovery](https://laravel-news.com/package-auto-discovery)