### PR TITLE
use laravel contract instead of dispatcher class

### DIFF
--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Larapack\VoyagerHooks;
 
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ServiceProvider;
 use Larapack\Hooks\Events\Setup;


### PR DESCRIPTION
it is possible to use this panel with OctoberCMS that is based on Laravel, but it uses custom EventDispatcher: https://github.com/octobercms/library/blob/master/src/Events/Dispatcher.php ; it follows dispatcher contract though -in general using contract is more generic solution