### PR TITLE
Replace canOrFail with authorize

### DIFF
--- a/src/Controllers/HooksController.php
+++ b/src/Controllers/HooksController.php
@@ -22,7 +22,7 @@ class HooksController extends Controller
     public function index()
     {
         // Check permission
-        Voyager::canOrFail('browse_hooks');
+        $this->authorize('browse_hooks');
 
         $lastUpdated = $this->hooks->getLastRemoteCheck();
 
@@ -41,7 +41,7 @@ class HooksController extends Controller
     public function install()
     {
         // Check permission
-        Voyager::canOrFail('browse_hooks');
+        $this->authorize('browse_hooks');
 
         $name = $this->request->get('name');
         $this->hooks->install($name);
@@ -52,7 +52,7 @@ class HooksController extends Controller
     public function uninstall($name)
     {
         // Check permission
-        Voyager::canOrFail('browse_hooks');
+        $this->authorize('browse_hooks');
 
         $this->hooks->uninstall($name);
 
@@ -62,7 +62,7 @@ class HooksController extends Controller
     public function update($name)
     {
         // Check permission
-        Voyager::canOrFail('browse_hooks');
+        $this->authorize('browse_hooks');
 
         $this->hooks->update($name);
 
@@ -72,7 +72,7 @@ class HooksController extends Controller
     public function enable($name)
     {
         // Check permission
-        Voyager::canOrFail('browse_hooks');
+        $this->authorize('browse_hooks');
 
         $this->hooks->enable($name);
 
@@ -82,7 +82,7 @@ class HooksController extends Controller
     public function disable($name)
     {
         // Check permission
-        Voyager::canOrFail('browse_hooks');
+        $this->authorize('browse_hooks');
 
         $this->hooks->disable($name);
 


### PR DESCRIPTION
In https://github.com/the-control-group/voyager/pull/3841 `can` `canOrFail` and `canOrAbort` were removed in favor of Policies and gates.
This PR replaces those calls.

Should probably not be released before a Voyager 1.2 release, or released in a new minor version.