### PR TITLE
Fix permission seeding

### DIFF
--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -124,7 +124,11 @@ class VoyagerHooksServiceProvider extends ServiceProvider
                         'table_name' => null,
                     ]);
 
-        $role = Role::where('name', 'admin')->firstOrFail();
+        if (config()->has('voyager.bread.default_role')) {
+            $role = Role::where('name', config('voyager.bread.default_role'))->firstOrFail();
+        } else {
+            $role = Role::where('name', 'admin')->firstOrFail();
+        }
 
         $role->permissions()->attach($permission);
     }

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -10,6 +10,7 @@ use Larapack\Hooks\HooksServiceProvider;
 use TCG\Voyager\Models\Menu;
 use TCG\Voyager\Models\MenuItem;
 use TCG\Voyager\Models\Permission;
+use TCG\Voyager\Models\Role;
 
 class VoyagerHooksServiceProvider extends ServiceProvider
 {
@@ -122,6 +123,14 @@ class VoyagerHooksServiceProvider extends ServiceProvider
             'key'        => 'browse_hooks',
             'table_name' => null,
         ]);
+
+        $role = Role::where('name', 'admin')->firstOrFail();
+
+        $permissions = Permission::all();
+
+        $role->permissions()->sync(
+            $permissions->pluck('id')->all()
+        );
     }
 
     public function publishVendorFiles()

--- a/src/VoyagerHooksServiceProvider.php
+++ b/src/VoyagerHooksServiceProvider.php
@@ -119,18 +119,14 @@ class VoyagerHooksServiceProvider extends ServiceProvider
 
     public function addHookPermissions()
     {
-        Permission::firstOrCreate([
-            'key'        => 'browse_hooks',
-            'table_name' => null,
-        ]);
+        $permission = Permission::firstOrCreate([
+                        'key'        => 'browse_hooks',
+                        'table_name' => null,
+                    ]);
 
         $role = Role::where('name', 'admin')->firstOrFail();
 
-        $permissions = Permission::all();
-
-        $role->permissions()->sync(
-            $permissions->pluck('id')->all()
-        );
+        $role->permissions()->attach($permission);
     }
 
     public function publishVendorFiles()


### PR DESCRIPTION
Hi, 

It seems that running `php artisan hook:setup` does not add the created permission to the permission_role table. I added this functionality in this PR because not adding the permission results in not being able to view the hooks menu item within the voyager admin dashboard.

It may not be the best way of doing it but it works like a charm.

If you have any questions please ask!

Kind regards,

Egidius Mengelberg